### PR TITLE
Add header for CORS

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -7,7 +7,6 @@ class Resource(object):
     def on_get(self, req, resp):
         """Handles GET requests"""
         resp.status = falcon.HTTP_200  # This is the default status
-        
 
         # TODO: 暫定修正
         client = pymongo.MongoClient(host='mongo', port=27017)


### PR DESCRIPTION
confirmed the behavior.
```
HTTP/1.1 200 OK
Server: nginx/1.15.1
Date: Fri, 13 Jul 2018 13:27:55 GMT
Content-Type: application/json; charset=UTF-8
Content-Length: 2
Connection: keep-alive
access-control-allow-origin: *
```