### PR TITLE
improve: open by new window

### DIFF
--- a/nginx/index.html
+++ b/nginx/index.html
@@ -109,7 +109,7 @@
                                     <div class="media-content">
                                         <p class="title is-4">
                                             <span v-show="proposal.is_adopted" class="tag cfp_adopted">採択</span>
-                                            <a :href="proposal.detail_url">{{ proposal.title }}</a>
+                                            <a :href="proposal.detail_url" target="_blank">{{ proposal.title }}</a>
                                         </p>
                                         <p class="subtitle is-6">{{ proposal.user }} / <a :href="'https://twitter.com/' +  proposal.twitter_id">@{{ proposal.twitter_id }}</a></p>
                                     </div>


### PR DESCRIPTION
元の詳細画面へ飛ぶリンクについて、新規Windowで開くようにしました。

理由は画面遷移してブラウザバックで戻ってくると、フィルタリング（検索ワード、採択チェック）がクリアされてしまい、また絞りこみ直しが必要になるためです。