### PR TITLE
update: replica size of nginx and web

### DIFF
--- a/nginx/nginx-deployment.yaml
+++ b/nginx/nginx-deployment.yaml
@@ -3,11 +3,11 @@ kind: Deployment
 metadata:
   name: nginx
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   selector:
     matchLabels:

--- a/web/web-deployment.yaml
+++ b/web/web-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: web
 spec:
-  replicas: 3
+  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 1


### PR DESCRIPTION
以下のように変更してみます。
```
Nginx：2 -> 1
Web：3 -> 2
```

まぁ本音を言えば`Web`も`1`で十分だろうと思うのですが、せっかくなのでReplicaするのを1つくらい残しておこうと（Kubernetes的な意味で