### PR TITLE
move and modified: slide link

### DIFF
--- a/nginx/index.html
+++ b/nginx/index.html
@@ -183,7 +183,7 @@
                                                 <span class="icon is-small">
                                                     <i class="fab fa-slideshare"></i>
                                                 </span>
-                                                <span>Slide</span>
+                                                <span>スライド</span>
                                             </a>
                                             {{ proposal.talk_type }}
                                         </span>


### PR DESCRIPTION
Edit slide link.
 - move from upper right to lower left
 - attach link & outlined button style,  thanks to YusukeHosonuma
 - add "Slide" text in button

<img width="846" alt="2018-09-11 23 18 13" src="https://user-images.githubusercontent.com/26447279/45366216-4867cd00-b619-11e8-9d7f-204fbc19bc8c.png">
