### PR TITLE
サマライズ処理をAPI側に移しました。

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - checkout
 
+      #
+      # run scraper tests
+      #
       - run:
           name: install dependencies
           command: |
@@ -22,7 +25,23 @@ jobs:
             . venv/bin/activate
             python cfp_scraping_test.py
           working_directory: scraper
-
       - store_artifacts:
           path: scraper/reports
           destination: test-reports
+
+      #
+      # run api tests
+      #
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+          working_directory: web
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python cfp_scraping_test.py
+          working_directory: web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            python cfp_scraping_test.py
+            python api_test.py
           working_directory: web

--- a/nginx/assets/index.js
+++ b/nginx/assets/index.js
@@ -56,7 +56,7 @@ const searchField = new Vue({
                 filteredData = proposalsMaster.filter(value =>
                     isKeywordMatch(value)
                         && (isAdopted(value) || isNotAdopted(value))
-                );    
+                );
             }
             proposalsInstance.proposals = filteredData;
         }
@@ -73,38 +73,7 @@ const proposalsInstance = new Vue({
 
 // プロポーザル一覧を読み込み
 axios.get('/api')
-.then(function (response) {
-
-    const proposals = []; // mutable
-
-    // Aggrigate the same talk types
-    response.data.forEach(pros => {
-
-        const found = proposals.find(element =>
-            element.user        == pros.user
-         && element.title       == pros.title
-         && element.description == pros.description
-        );
-
-        pros.orecon_form_url = "https://docs.google.com/forms/d/e/1FAIpQLSfFaoVGH__Ck-CzdnH83ZC_1PlFewXsJmoEe68mhrNfeRLA4w/viewform?entry.1898580758=" + pros.detail_url;
-
-        if (found) {
-             const talk_type = found.talk_type + ' / ' + pros.talk_type;
-             found.talk_type = talk_type.split(' / ').sort().join(' / ');
-             if (pros.is_adopted || pros.is_adopted_rejectcon || pros.is_adopted_orecon) {
-                found.is_adopted           = pros.is_adopted;
-                found.is_adopted_orecon    = pros.is_adopted_orecon;
-                found.is_adopted_rejectcon = pros.is_adopted_rejectcon;
-                found.description          = pros.description;
-                found.detail_url           = pros.detail_url;
-                found.orecon_form_url      = pros.orecon_form_url;
-                found.video_url            = pros.video_url;
-             }
-        } else {
-            proposals.push(pros);
-        }
-    });
-
-    proposalsMaster = proposals;
-    proposalsInstance.proposals = proposals;
-})
+    .then(function (response) {
+        proposalsMaster = response.data;
+        proposalsInstance.proposals = response.data;
+    })

--- a/web/api.py
+++ b/web/api.py
@@ -65,7 +65,6 @@ def summarize_proposal(src, dest):
     copy_if(src, dest, 'is_adopted_rejectcon')
     copy_if(src, dest, 'description')
     copy_if(src, dest, 'detail_url')
-    copy_if(src, dest, 'orecon_form_url')
     copy_if(src, dest, 'video_url')
 
 

--- a/web/api.py
+++ b/web/api.py
@@ -12,6 +12,7 @@ class Resource(object):
         client = pymongo.MongoClient(host='mongo', port=27017)
         db = client.iosdc2018_phase_2
         datas = list(db.cfps.find({}, { '_id': False }).sort([("title", pymongo.ASCENDING)]))
+        datas = summarize_proposals(datas)
         resp.body = dumps(datas, ensure_ascii=False)
         resp.append_header('Access-Control-Allow-Origin', '*')
 
@@ -36,9 +37,12 @@ def summarize_proposals(datas):
             return acr
         else:
             found = xs[0]
-            found['talk_type'] = found['talk_type'] + ' / ' + data['talk_type']
+            talk_types = found['talk_type'].split(' / ')
+            if data['talk_type'] not in talk_types:
+                talk_types.append(data['talk_type'])
+                found['talk_type'] = ' / '.join(sorted(talk_types))
             # 採択された方のデータを正とする
-            if data['is_adopted'] or data['is_adopted_rejectcon'] or data['is_adopted_orecon']:
+            if data.get('is_adopted') == True or data.get('is_adopted_rejectcon') == True or data.get('is_adopted_orecon') == True:
                 summarize_proposal(data, found)
             return acr
 

--- a/web/api_test.py
+++ b/web/api_test.py
@@ -8,29 +8,43 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（15分）",
+                "talk_type": "レギュラートーク（30分）",
                 "detail_url": "http://example.com/0",
             },
             {
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_type": "レギュラートーク（15分）",
                 "detail_url": "http://example.com/1",
+            },
+            {
+                "title": "goodbye",
+                "user": "user3",
+                "is_adopted": True,
+                "talk_type": "レギュラートーク（15分）",
+                "detail_url": "http://example.com/2",
+            },
+            {
+                "title": "goodbye",
+                "user": "user3",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（15分）",
+                "detail_url": "http://example.com/3",
             },
             {
                 "title": "hello2",
                 "user": "user1",
                 "is_adopted": False,
                 "talk_type": "レギュラートーク（30分）",
-                "detail_url": "http://example.com/2",
+                "detail_url": "http://example.com/4",
             },
             {
                 "title": "hello",
                 "user": "user2",
                 "is_adopted": False,
                 "talk_type": "レギュラートーク（30分）",
-                "detail_url": "http://example.com/3",
+                "detail_url": "http://example.com/5",
             }
         ]
         datas = api.summarize_proposals(datas)
@@ -41,8 +55,16 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（15分） / レギュラートーク（30分）",
+                "talk_type": "レギュラートーク（15分） / レギュラートーク（30分）", # 文字列の昇順でソート
                 "detail_url": "http://example.com/1",
+            },
+            # 同一のトークタイプは集約されること
+            {
+                "title": "goodbye",
+                "user": "user3",
+                "is_adopted": True,
+                "talk_type": "レギュラートーク（15分）",
+                "detail_url": "http://example.com/2",
             },
             # title が不一致なものは集約されないこと
             {
@@ -50,7 +72,7 @@ class TestSummarize(unittest.TestCase):
                 "user": "user1",
                 "is_adopted": False,
                 "talk_type": "レギュラートーク（30分）",
-                "detail_url": "http://example.com/2",
+                "detail_url": "http://example.com/4",
             },
             # user が不一致なものは集約されないこと
             {
@@ -58,7 +80,7 @@ class TestSummarize(unittest.TestCase):
                 "user": "user2",
                 "is_adopted": False,
                 "talk_type": "レギュラートーク（30分）",
-                "detail_url": "http://example.com/3",
+                "detail_url": "http://example.com/5",
             },
         ])
 

--- a/web/api_test.py
+++ b/web/api_test.py
@@ -1,0 +1,67 @@
+import unittest
+import api as api
+
+class TestSummarize(unittest.TestCase):
+    def test_summarize_proposals(self):
+        datas = [
+            {
+                "title": "hello",
+                "user": "user1",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（15分）",
+                "detail_url": "http://example.com/0",
+            },
+            {
+                "title": "hello",
+                "user": "user1",
+                "is_adopted": True,
+                "talk_type": "レギュラートーク（30分）",
+                "detail_url": "http://example.com/1",
+            },
+            {
+                "title": "hello2",
+                "user": "user1",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（30分）",
+                "detail_url": "http://example.com/2",
+            },
+            {
+                "title": "hello",
+                "user": "user2",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（30分）",
+                "detail_url": "http://example.com/3",
+            }
+        ]
+        datas = api.summarize_proposals(datas)
+
+        self.assertEqual(datas, [
+            # title / user が同一のものは集約されること
+            {
+                "title": "hello",
+                "user": "user1",
+                "is_adopted": True,
+                "talk_type": "レギュラートーク（15分） / レギュラートーク（30分）",
+                "detail_url": "http://example.com/1",
+            },
+            # title が不一致なものは集約されないこと
+            {
+                "title": "hello2",
+                "user": "user1",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（30分）",
+                "detail_url": "http://example.com/2",
+            },
+            # user が不一致なものは集約されないこと
+            {
+                "title": "hello",
+                "user": "user2",
+                "is_adopted": False,
+                "talk_type": "レギュラートーク（30分）",
+                "detail_url": "http://example.com/3",
+            },
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
今までフロント（`index.js`）でやっていたサマライズ処理（*1）をAPI側（`web/api.py`）に移しました。（ #67 ）

通信量の削減と、クライアント側の負荷軽減が見込めます。