### PR TITLE
API：トークの種類を`talk_types`というキーで配列で返すようにします。

### DIFF
--- a/nginx/assets/index.js
+++ b/nginx/assets/index.js
@@ -74,6 +74,17 @@ const proposalsInstance = new Vue({
 // プロポーザル一覧を読み込み
 axios.get('/api')
     .then(function (response) {
-        proposalsMaster = response.data;
-        proposalsInstance.proposals = response.data;
+        let proposals = response.data.map(proposal => {
+            const dict = {
+                'LT': 'LT（5分）',
+                'LT_R': 'iOSDCルーキーズ LT（5分）',
+                '15m': 'レギュラートーク（15分）',
+                '30m': 'レギュラートーク（30分）',
+                'iOS': 'iOSエンジニアに聞いて欲しいトーク（30分）',
+            }
+            proposal.talk_type = proposal.talk_types.map(talk_type => dict[talk_type]).join(' / ')
+            return proposal
+        });
+        proposalsMaster = proposals;
+        proposalsInstance.proposals = proposals;
     })

--- a/scraper/cfp_scraping.py
+++ b/scraper/cfp_scraping.py
@@ -186,6 +186,7 @@ class CFP:
             if len(slide_url) > 0:
                 cfp.slide_url = slide_url[0].attrib['href']
         cfp.desc()
+        cfp.normalization()
         return cfp
 
 if __name__ == '__main__':

--- a/scraper/cfp_scraping.py
+++ b/scraper/cfp_scraping.py
@@ -91,6 +91,16 @@ class CFP:
                 'slide_url': self.slide_url
                 }
 
+    def normalization(self):
+        dict = {
+            'LT（5分）': 'LT',
+            'iOSDCルーキーズ LT（5分）': 'LT_R',
+            'レギュラートーク（15分）': '15m',
+            'レギュラートーク（30分）': '30m',
+            'iOSエンジニアに聞いて欲しいトーク（30分）': 'iOS'
+        }
+        self.talk_type = dict[self.talk_type]
+
     def desc(self):
         print(f"""-------------------------------------------------------------------
 【title】

--- a/scraper/cfp_scraping_test.py
+++ b/scraper/cfp_scraping_test.py
@@ -21,5 +21,13 @@ class TestCfpScraping(unittest.TestCase):
         self.assertEqual(cfp.slide_url, 'https://speakerdeck.com/keisuke69/the-revolution-of-real-time-webapps')
 
 
+class TestCFP(unittest.TestCase):
+    def test_normalization(self):
+        cfp = scraping.CFP()
+        cfp.talk_type = 'レギュラートーク（30分）'
+        cfp.normalization()
+        self.assertEqual(cfp.talk_type, '30m')
+
+
 if __name__ == "__main__":
     unittest.main(testRunner=HtmlTestRunner.HTMLTestRunner(output='TestCfpScraping'))

--- a/scraper/cfp_scraping_test.py
+++ b/scraper/cfp_scraping_test.py
@@ -9,7 +9,7 @@ class TestCfpScraping(unittest.TestCase):
         cfp = cfps[0]
         self.assertEqual(cfp.title, 'リアルタイム革命')
         self.assertEqual(cfp.user, '西谷圭介')
-        self.assertEqual(cfp.talk_type, 'レギュラートーク（30分）')
+        self.assertEqual(cfp.talk_type, '30m')
         self.assertEqual(cfp.description, 'チャットに代表されるリアルタイムなアプリケーションを皆さんはどのように開発していますか？リアルタイムな双方向通信をサポートするソリューションを利用したり、Socket.ioなどを用いてWebSocketで自前で構築するなどあると思います。本セッションでは新たなクエリ言語として注目されるGraphQLのSubscriptionを用いる方法をGraphQLのマネージドサービスであるAWS AppSyncとあわせてご紹介します。')
         self.assertEqual(cfp.icon_url, 'https://fortee.jp/files/iosdc-japan-2018/speaker/a671c733-f784-4e63-847d-6688a7521f62.jpeg')
         self.assertEqual(cfp.twitter_id, 'Keisuke69')

--- a/web/api.py
+++ b/web/api.py
@@ -33,14 +33,17 @@ def summarize_proposals(datas):
     def f(acr, data):
         xs = list(filter(lambda x: is_same_proposal(x, data), acr))
         if len(xs) == 0:
+            data['talk_types'] = [data['talk_type']]
+            del data['talk_type'] # remove original key
             acr.append(data)
             return acr
         else:
             found = xs[0]
-            talk_types = found['talk_type'].split(' / ')
-            if data['talk_type'] not in talk_types:
-                talk_types.append(data['talk_type'])
-                found['talk_type'] = ' / '.join(sorted(talk_types))
+            talk_type = data['talk_type']
+            talk_types = found['talk_types']
+            if talk_type not in talk_types:
+                talk_types.append(talk_type)
+                found['talk_types'] = sorted(talk_types)
             # 採択された方のデータを正とする
             if data.get('is_adopted') == True or data.get('is_adopted_rejectcon') == True or data.get('is_adopted_orecon') == True:
                 summarize_proposal(data, found)

--- a/web/api_test.py
+++ b/web/api_test.py
@@ -55,7 +55,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（15分） / レギュラートーク（30分）", # 文字列の昇順でソート
+                "talk_types": ["レギュラートーク（15分）", "レギュラートーク（30分）"], # 文字列の昇順でソート
                 "detail_url": "http://example.com/1",
             },
             # 同一のトークタイプは集約されること
@@ -63,7 +63,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "goodbye",
                 "user": "user3",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（15分）",
+                "talk_types": ["レギュラートーク（15分）"],
                 "detail_url": "http://example.com/2",
             },
             # title が不一致なものは集約されないこと
@@ -71,7 +71,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello2",
                 "user": "user1",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_types": ["レギュラートーク（30分）"],
                 "detail_url": "http://example.com/4",
             },
             # user が不一致なものは集約されないこと
@@ -79,7 +79,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user2",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_types": ["レギュラートーク（30分）"],
                 "detail_url": "http://example.com/5",
             },
         ])

--- a/web/api_test.py
+++ b/web/api_test.py
@@ -8,42 +8,42 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_type": "30m",
                 "detail_url": "http://example.com/0",
             },
             {
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（15分）",
+                "talk_type": "15m",
                 "detail_url": "http://example.com/1",
             },
             {
                 "title": "goodbye",
                 "user": "user3",
                 "is_adopted": True,
-                "talk_type": "レギュラートーク（15分）",
+                "talk_type": "15m",
                 "detail_url": "http://example.com/2",
             },
             {
                 "title": "goodbye",
                 "user": "user3",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（15分）",
+                "talk_type": "15m",
                 "detail_url": "http://example.com/3",
             },
             {
                 "title": "hello2",
                 "user": "user1",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_type": "30m",
                 "detail_url": "http://example.com/4",
             },
             {
                 "title": "hello",
                 "user": "user2",
                 "is_adopted": False,
-                "talk_type": "レギュラートーク（30分）",
+                "talk_type": "30m",
                 "detail_url": "http://example.com/5",
             }
         ]
@@ -55,7 +55,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user1",
                 "is_adopted": True,
-                "talk_types": ["レギュラートーク（15分）", "レギュラートーク（30分）"], # 文字列の昇順でソート
+                "talk_types": ["15m", "30m"], # 文字列の昇順でソート
                 "detail_url": "http://example.com/1",
             },
             # 同一のトークタイプは集約されること
@@ -63,7 +63,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "goodbye",
                 "user": "user3",
                 "is_adopted": True,
-                "talk_types": ["レギュラートーク（15分）"],
+                "talk_types": ["15m"],
                 "detail_url": "http://example.com/2",
             },
             # title が不一致なものは集約されないこと
@@ -71,7 +71,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello2",
                 "user": "user1",
                 "is_adopted": False,
-                "talk_types": ["レギュラートーク（30分）"],
+                "talk_types": ["30m"],
                 "detail_url": "http://example.com/4",
             },
             # user が不一致なものは集約されないこと
@@ -79,7 +79,7 @@ class TestSummarize(unittest.TestCase):
                 "title": "hello",
                 "user": "user2",
                 "is_adopted": False,
-                "talk_types": ["レギュラートーク（30分）"],
+                "talk_types": ["30m"],
                 "detail_url": "http://example.com/5",
             },
         ])


### PR DESCRIPTION
API側で`レギュラートーク（15分） / レギュラートーク（30分）`といった感じに文字列で組み立てていたものを、`['15m', '30m']`といった感じで配列で返却し、表示用の文字列整形はWeb側（`index.js`）で行うようにしました。

あわせて、元のキーは`talk_type`という単数形でしたが、複数になったので`talk_types`にキー名を変更しています。

なお、具体的な返却値については #150 にてドキュメント化する予定です。